### PR TITLE
Fill the edit card form with superclass

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": [ "es2015" ]
+  "presets": [ "es2015", "react" ]
 }

--- a/package.json
+++ b/package.json
@@ -11,28 +11,34 @@
   "private": true,
   "scripts": {
     "build": "gulp",
-    "watch": "gulp watch"
+    "watch": "gulp watch",
+    "check": "jest"
   },
   "dependencies": {
     "clipboard": "^1.5.12",
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2"
+    "react": "^15.3.1",
+    "react-dom": "^15.3.1"
   },
   "devDependencies": {
-    "babel-plugin-transform-class-properties": "^6.16.0",
+    "babel-jest": "^15.0.0",
+    "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
-    "babel-register": "^6.16.3",
+    "babel-register": "^6.14.0",
     "babelify": "^7.3.0",
-    "browser-sync": "^2.17.0",
+    "browser-sync": "^2.16.0",
     "browserify": "^13.1.0",
     "del": "^2.2.2",
+    "enzyme": "^2.4.1",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-cssnano": "^2.1.2",
     "gulp-gh-pages": "^0.5.4",
-    "gulp-htmlmin": "^3.0.0",
+    "gulp-htmlmin": "^2.0.0",
     "gulp-sass": "^2.3.2",
     "gulp-uglify": "^2.0.0",
+    "jest": "^15.1.1",
+    "react-addons-test-utils": "^15.3.2",
+    "react-test-renderer": "^15.3.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }

--- a/src/components/NewCardForm.js
+++ b/src/components/NewCardForm.js
@@ -70,7 +70,7 @@ export default class NewCardForm extends Component {
         <input ref='name' type='text' defaultValue={data ? data.name : ''} />
 
         <label>Superclasses:</label>
-        <input ref='superclasses' type='text' defaultValue={data ? data.super : ''} />
+        <input id='ncfSuperclass' ref='superclasses' type='text' defaultValue={data ? data.superclasses : ''} />
 
         <label>Subclasses:</label>
         <input ref='subclasses' type='text' defaultValue={data ? data.sub : ''} />

--- a/src/components/NewCardForm.test.js
+++ b/src/components/NewCardForm.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import NewCardForm from './NewCardForm';
+
+it('loads the superclass in the form', () => {
+  let testData = {
+    name: "TheName",
+    superclasses: "TheSuperclass",
+    responsibilities: [],
+    collaborators: []
+  };
+  let noAction = () => true;
+  let component = shallow(
+    <NewCardForm onAdd={noAction} onCancel={noAction} data={testData} />
+  );
+
+  expect(component.find('input#ncfSuperclass').props().defaultValue).toEqual(testData.superclasses);
+});


### PR DESCRIPTION
Hello there,

Nice work on your CRCMaker. I like it.

I found that when I create a card that has a superclass and then go back and edit the card, then the superclass is lost.

I found the culprit and took the liberty of adding a simple little unit test that targets the bug.

The same issue occurs with subclasses as well but I left that. Who the hell wants to put subclasses on CRC cards?

Cheers,
Paddy